### PR TITLE
Update branch name regexp (#6, #9)

### DIFF
--- a/Jira_Task2Branch.user.js
+++ b/Jira_Task2Branch.user.js
@@ -10,7 +10,7 @@
 // @grant        none
 // @license      MIT
 // ==/UserScript==
-const REGEXP = /[\s\[\]:\\\/\"\|\'-\.\,`<\>]+/g;
+const REGEXP = /[\s\[\]\\\-/:"“`'|.,<>#~*?^]+/g;
 const MAX_LENGTH = 60;
 const DIVIDER = '-';
 const TEXT_COPY_BRANCH_NAME = 'Branch Name';


### PR DESCRIPTION
- Add more forbidden characters to branch name regexp. Based on https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html
- Put characters that don't need to be escaped at the end of the range